### PR TITLE
link to another simplex solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Stellar Implementation: https://github.com/gramseyer/stellar-core/blob/master/sr
 
 Simple Simplex LP Solver: https://github.com/gramseyer/stellar-core/tree/master/src/simplex
 
+Faster LP Solver: https://github.com/scslab/speedex/tree/master/simplex/
+
 Tatonnement
 
 1) Collect DB of transactions for a given block


### PR DESCRIPTION
A link to another solver for the same LP, along with checking feasibility of the LP if lower bounds are imposed (i.e. offers less than (1-alpha) have to trade in full).  

The main difference is a sparse internal representation of the constraint matrix.  Doesn't change the external interface, but the non-sparse representation doesn't seem to scale past 10 or so assets (whereas the sparse rep will go to ~80 or 100)